### PR TITLE
Use ip route for route deletion

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -54,10 +54,10 @@ pub fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<()> {
 pub fn tproxy_remove(tproxy_args: &TproxyArgs) -> std::io::Result<()> {
     // sudo route del bypass_ip
     for bypass_ip in tproxy_args.bypass_ips.iter() {
-        let args = &["del", &bypass_ip.to_string()];
-        if let Err(_err) = run_command("route", args) {
+        let args = &["route", "del", &bypass_ip.to_string()];
+        if let Err(_err) = run_command("ip", args) {
             #[cfg(feature = "log")]
-            log::debug!("command \"route del {}\" error: {}", bypass_ip, _err);
+            log::debug!("command \"ip route del {}\" error: {}", bypass_ip, _err);
         }
     }
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -52,7 +52,7 @@ pub fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<()> {
 }
 
 pub fn tproxy_remove(tproxy_args: &TproxyArgs) -> std::io::Result<()> {
-    // sudo route del bypass_ip
+    // sudo ip route del bypass_ip
     for bypass_ip in tproxy_args.bypass_ips.iter() {
         let args = &["route", "del", &bypass_ip.to_string()];
         if let Err(_err) = run_command("ip", args) {


### PR DESCRIPTION
The `route` command is not part of `iproute2`, which provides the `ip` command. We should be consistent in using the `ip` command. On the DigitalOcean VPS I performed a test on, `route` was unavailable.