### PR TITLE
Implement destructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tproxy-config"
-version = "3.0.1"
+version = "4.0.1"
 edition = "2021"
 description = "Transparent proxy configuration"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tproxy-config"
-version = "4.0.1"
+version = "3.0.2"
 edition = "2021"
 description = "Transparent proxy configuration"
 license = "MIT"
@@ -10,6 +10,7 @@ keywords = ["tun", "network", "tunnel", "transparent", "proxy"]
 readme = "readme.md"
 
 [features]
+default = []
 log = ["dep:log"]
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@ use std::{
 pub use {private_ip::is_private_ip, tproxy_args::TproxyArgs};
 
 #[cfg(target_os = "linux")]
-pub use linux::tproxy_setup;
+pub use linux::{tproxy_remove, tproxy_setup};
 
 #[cfg(target_os = "windows")]
-pub use windows::tproxy_setup;
+pub use windows::{tproxy_remove, tproxy_setup};
 
 #[cfg(target_os = "macos")]
-pub use macos::tproxy_setup;
+pub use macos::{tproxy_remove, tproxy_setup};
 
 pub const TUN_NAME: &str = if cfg!(target_os = "linux") {
     "tun0"
@@ -66,6 +66,7 @@ pub struct TproxyState {
     pub(crate) gw_scope: Option<String>,
     pub(crate) umount_resolvconf: bool,
     pub(crate) restore_resolvconf_content: Option<Vec<u8>>,
+    pub(crate) tproxy_removed_done: bool,
 }
 
 #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@ use std::{
 pub use {private_ip::is_private_ip, tproxy_args::TproxyArgs};
 
 #[cfg(target_os = "linux")]
-pub use {linux::tproxy_remove, linux::tproxy_setup};
+pub use linux::tproxy_setup;
 
 #[cfg(target_os = "windows")]
-pub use {windows::tproxy_remove, windows::tproxy_setup};
+pub use windows::tproxy_setup;
 
 #[cfg(target_os = "macos")]
-pub use {macos::tproxy_remove, macos::tproxy_setup};
+pub use macos::tproxy_setup;
 
 pub const TUN_NAME: &str = if cfg!(target_os = "linux") {
     "tun0"

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -77,92 +77,100 @@ pub fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<TproxyState> {
         original_dns_servers: Some(original_dns_servers),
         gateway: Some(original_gateway_0),
         gw_scope: Some(orig_gw_iface),
-        ..TproxyState::default()
+        umount_resolvconf: false,
+        restore_resolvconf_content: None,
     };
     crate::store_intermediate_state(&restore)?;
 
     Ok(restore)
 }
 
-pub fn tproxy_remove(tproxy_restore: Option<TproxyState>) -> std::io::Result<()> {
-    let mut state = match tproxy_restore {
-        Some(restore) => restore,
-        None => crate::retrieve_intermediate_state()?,
-    };
-
-    let original_dns_servers = state.original_dns_servers.take().unwrap_or_default();
-
-    let err = std::io::Error::new(std::io::ErrorKind::Other, "No original gateway found");
-    let original_gateway = state.gateway.take().ok_or(err)?.to_string();
-    let err = std::io::Error::new(std::io::ErrorKind::Other, "No original gateway scope found");
-    let original_gw_scope = state.gw_scope.take().ok_or(err)?;
-
-    if let Err(_err) = configure_system_proxy(false, None, None) {
+impl Drop for TproxyState {
+    fn drop(&mut self) {
         #[cfg(feature = "log")]
-        log::debug!("configure_system_proxy error: {}", _err);
-    }
-    if !original_dns_servers.is_empty() {
-        if let Err(_err) = configure_dns_servers(&original_dns_servers) {
+        log::debug!("restoring network settings");
+
+        if let Err(_e) = (|| -> std::io::Result<()> {
+            let state = self;
+
+            let original_dns_servers = state.original_dns_servers.take().unwrap_or_default();
+
+            let err = std::io::Error::new(std::io::ErrorKind::Other, "No original gateway found");
+            let original_gateway = state.gateway.take().ok_or(err)?.to_string();
+            let err = std::io::Error::new(std::io::ErrorKind::Other, "No original gateway scope found");
+            let original_gw_scope = state.gw_scope.take().ok_or(err)?;
+
+            if let Err(_err) = configure_system_proxy(false, None, None) {
+                #[cfg(feature = "log")]
+                log::debug!("configure_system_proxy error: {}", _err);
+            }
+            if !original_dns_servers.is_empty() {
+                if let Err(_err) = configure_dns_servers(&original_dns_servers) {
+                    #[cfg(feature = "log")]
+                    log::debug!("restore original dns servers error: {}", _err);
+                }
+            }
+
+            let err = std::io::Error::new(std::io::ErrorKind::InvalidData, "tproxy_args is None");
+            let tproxy_args = state.tproxy_args.as_ref().ok_or(err)?;
+
+            // Command: `sudo route delete bypass_ip`
+            for bypass_ip in tproxy_args.bypass_ips.iter() {
+                let args = &["delete", &bypass_ip.to_string()];
+                run_command("route", args)?;
+            }
+            if tproxy_args.bypass_ips.is_empty() && !crate::is_private_ip(tproxy_args.proxy_addr.ip()) {
+                let bypass_ip = tproxy_args.proxy_addr.ip();
+                let args = &["delete", &bypass_ip.to_string()];
+                run_command("route", args)?;
+            }
+
+            // route delete default
+            // route delete default -ifscope original_gw_scope
+            // route add default original_gateway
+            if let Err(_err) = run_command("route", &["delete", "default"]) {
+                #[cfg(feature = "log")]
+                log::debug!("command \"route delete default\" error: {}", _err);
+            }
+            if let Err(_err) = run_command("route", &["delete", "default", "-ifscope", &original_gw_scope]) {
+                #[cfg(feature = "log")]
+                log::debug!("command \"route delete default -ifscope {}\" error: {}", original_gw_scope, _err);
+            }
+            if let Err(_err) = run_command("route", &["add", "default", &original_gateway]) {
+                #[cfg(feature = "log")]
+                log::debug!("command \"route add default {}\" error: {}", original_gateway, _err);
+            }
+
+            /*
+            let unspecified = Ipv4Addr::UNSPECIFIED.to_string();
+
+            // 1. Remove current adapter's route
+            // command: `sudo route delete 0.0.0.0`
+            let args = &["delete", &unspecified];
+            run_command("route", args)?;
+
+            // 2. Add back the original gateway route
+            // command: `sudo route add -net 0.0.0.0 original_gateway`
+            let args = &["add", "-net", &unspecified, &original_gateway];
+            run_command("route", args)?;
+            // */
+
+            // 3. Restore DNS server to the original gateway
+            // command: `sudo sh -c "echo nameserver original_gateway > /etc/resolv.conf"`
+            let file = std::fs::OpenOptions::new().write(true).truncate(true).open(ETC_RESOLV_CONF_FILE)?;
+            let mut writer = std::io::BufWriter::new(file);
+            use std::io::Write;
+            writeln!(writer, "nameserver {}\n", original_gateway)?;
+
+            // remove the record file anyway
+            let _ = std::fs::remove_file(crate::get_state_file_path());
+
+            Ok(())
+        })() {
             #[cfg(feature = "log")]
-            log::debug!("restore original dns servers error: {}", _err);
+            log::error!("failed to restore network settings: {}", _e);
         }
     }
-
-    let err = std::io::Error::new(std::io::ErrorKind::InvalidData, "tproxy_args is None");
-    let tproxy_args = state.tproxy_args.as_ref().ok_or(err)?;
-
-    // Command: `sudo route delete bypass_ip`
-    for bypass_ip in tproxy_args.bypass_ips.iter() {
-        let args = &["delete", &bypass_ip.to_string()];
-        run_command("route", args)?;
-    }
-    if tproxy_args.bypass_ips.is_empty() && !crate::is_private_ip(tproxy_args.proxy_addr.ip()) {
-        let bypass_ip = tproxy_args.proxy_addr.ip();
-        let args = &["delete", &bypass_ip.to_string()];
-        run_command("route", args)?;
-    }
-
-    // route delete default
-    // route delete default -ifscope original_gw_scope
-    // route add default original_gateway
-    if let Err(_err) = run_command("route", &["delete", "default"]) {
-        #[cfg(feature = "log")]
-        log::debug!("command \"route delete default\" error: {}", _err);
-    }
-    if let Err(_err) = run_command("route", &["delete", "default", "-ifscope", &original_gw_scope]) {
-        #[cfg(feature = "log")]
-        log::debug!("command \"route delete default -ifscope {}\" error: {}", original_gw_scope, _err);
-    }
-    if let Err(_err) = run_command("route", &["add", "default", &original_gateway]) {
-        #[cfg(feature = "log")]
-        log::debug!("command \"route add default {}\" error: {}", original_gateway, _err);
-    }
-
-    /*
-    let unspecified = Ipv4Addr::UNSPECIFIED.to_string();
-
-    // 1. Remove current adapter's route
-    // command: `sudo route delete 0.0.0.0`
-    let args = &["delete", &unspecified];
-    run_command("route", args)?;
-
-    // 2. Add back the original gateway route
-    // command: `sudo route add -net 0.0.0.0 original_gateway`
-    let args = &["add", "-net", &unspecified, &original_gateway];
-    run_command("route", args)?;
-    // */
-
-    // 3. Restore DNS server to the original gateway
-    // command: `sudo sh -c "echo nameserver original_gateway > /etc/resolv.conf"`
-    let file = std::fs::OpenOptions::new().write(true).truncate(true).open(ETC_RESOLV_CONF_FILE)?;
-    let mut writer = std::io::BufWriter::new(file);
-    use std::io::Write;
-    writeln!(writer, "nameserver {}\n", original_gateway)?;
-
-    // remove the record file anyway
-    let _ = std::fs::remove_file(crate::get_state_file_path());
-
-    Ok(())
 }
 
 pub(crate) fn get_default_gateway() -> std::io::Result<(IpAddr, String)> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -32,8 +32,11 @@ pub fn tproxy_setup(tproxy_args: &TproxyArgs) -> std::io::Result<TproxyState> {
 
     let restore = TproxyState {
         tproxy_args: Some(tproxy_args.clone()),
+        original_dns_servers: None,
         gateway: Some(original_gateway),
-        ..TproxyState::default()
+        gw_scope: None,
+        umount_resolvconf: false,
+        restore_resolvconf_content: None,
     };
     crate::store_intermediate_state(&restore)?;
 
@@ -50,67 +53,74 @@ fn do_bypass_ip(bypass_ip: IpAddr, original_gateway: IpAddr) -> std::io::Result<
     Ok(())
 }
 
-pub fn tproxy_remove(tproxy_restore: Option<TproxyState>) -> std::io::Result<()> {
-    let mut state = match tproxy_restore {
-        Some(restore) => restore,
-        None => crate::retrieve_intermediate_state()?,
-    };
-
-    let err = std::io::Error::new(std::io::ErrorKind::InvalidData, "tproxy_args is None");
-    let tproxy_args = state.tproxy_args.as_ref().ok_or(err)?;
-
-    let err = std::io::Error::new(std::io::ErrorKind::Other, "No default gateway found");
-    let original_gateway = state.gateway.take().ok_or(err)?;
-    let unspecified = Ipv4Addr::UNSPECIFIED.to_string();
-
-    // 0. delete persistent route
-    // command: `route -p delete 0.0.0.0 mask 0.0.0.0 10.0.0.1`
-    let gateway = tproxy_args.tun_gateway.to_string();
-    let args = &["-p", "delete", &unspecified, "mask", &unspecified, &gateway];
-    if let Err(_err) = run_command("route", args) {
+impl Drop for TproxyState {
+    fn drop(&mut self) {
         #[cfg(feature = "log")]
-        log::debug!("command \"route {:?}\" error: {}", args, _err);
-    }
+        log::debug!("restoring network settings");
 
-    // Remove bypass ips
-    // command: `route delete bypass_ip`
-    for bypass_ip in tproxy_args.bypass_ips.iter() {
-        let args = &["delete", &bypass_ip.to_string()];
-        if let Err(_err) = run_command("route", args) {
+        if let Err(_e) = (|| -> std::io::Result<()> {
+            let state = self;
+
+            let err = std::io::Error::new(std::io::ErrorKind::InvalidData, "tproxy_args is None");
+            let tproxy_args = state.tproxy_args.as_ref().ok_or(err)?;
+
+            let err = std::io::Error::new(std::io::ErrorKind::Other, "No default gateway found");
+            let original_gateway = state.gateway.take().ok_or(err)?;
+            let unspecified = Ipv4Addr::UNSPECIFIED.to_string();
+
+            // 0. delete persistent route
+            // command: `route -p delete 0.0.0.0 mask 0.0.0.0 10.0.0.1`
+            let gateway = tproxy_args.tun_gateway.to_string();
+            let args = &["-p", "delete", &unspecified, "mask", &unspecified, &gateway];
+            if let Err(_err) = run_command("route", args) {
+                #[cfg(feature = "log")]
+                log::debug!("command \"route {:?}\" error: {}", args, _err);
+            }
+
+            // Remove bypass ips
+            // command: `route delete bypass_ip`
+            for bypass_ip in tproxy_args.bypass_ips.iter() {
+                let args = &["delete", &bypass_ip.to_string()];
+                if let Err(_err) = run_command("route", args) {
+                    #[cfg(feature = "log")]
+                    log::debug!("command \"route {:?}\" error: {}", args, _err);
+                }
+            }
+            if tproxy_args.bypass_ips.is_empty() && !crate::is_private_ip(tproxy_args.proxy_addr.ip()) {
+                let bypass_ip = tproxy_args.proxy_addr.ip();
+                let args = &["delete", &bypass_ip.to_string()];
+                if let Err(_err) = run_command("route", args) {
+                    #[cfg(feature = "log")]
+                    log::debug!("command \"route {:?}\" error: {}", args, _err);
+                }
+            }
+
+            // 1. Remove current adapter's route
+            // command: `route delete 0.0.0.0 mask 0.0.0.0`
+            let args = &["delete", &unspecified, "mask", &unspecified];
+            if let Err(_err) = run_command("route", args) {
+                #[cfg(feature = "log")]
+                log::debug!("command \"route {:?}\" error: {}", args, _err);
+            }
+
+            // 2. Add back the original gateway route
+            // command: `route add 0.0.0.0 mask 0.0.0.0 original_gateway metric 200`
+            let original_gateway = original_gateway.to_string();
+            let args = &["add", &unspecified, "mask", &unspecified, &original_gateway, "metric", "200"];
+            if let Err(_err) = run_command("route", args) {
+                #[cfg(feature = "log")]
+                log::debug!("command \"route {:?}\" error: {}", args, _err);
+            }
+
+            // remove the record file anyway
+            let _ = std::fs::remove_file(crate::get_state_file_path());
+
+            Ok(())
+        })() {
             #[cfg(feature = "log")]
-            log::debug!("command \"route {:?}\" error: {}", args, _err);
+            log::error!("failed to restore network settings: {}", _e);
         }
     }
-    if tproxy_args.bypass_ips.is_empty() && !crate::is_private_ip(tproxy_args.proxy_addr.ip()) {
-        let bypass_ip = tproxy_args.proxy_addr.ip();
-        let args = &["delete", &bypass_ip.to_string()];
-        if let Err(_err) = run_command("route", args) {
-            #[cfg(feature = "log")]
-            log::debug!("command \"route {:?}\" error: {}", args, _err);
-        }
-    }
-
-    // 1. Remove current adapter's route
-    // command: `route delete 0.0.0.0 mask 0.0.0.0`
-    let args = &["delete", &unspecified, "mask", &unspecified];
-    if let Err(_err) = run_command("route", args) {
-        #[cfg(feature = "log")]
-        log::debug!("command \"route {:?}\" error: {}", args, _err);
-    }
-
-    // 2. Add back the original gateway route
-    // command: `route add 0.0.0.0 mask 0.0.0.0 original_gateway metric 200`
-    let original_gateway = original_gateway.to_string();
-    let args = &["add", &unspecified, "mask", &unspecified, &original_gateway, "metric", "200"];
-    if let Err(_err) = run_command("route", args) {
-        #[cfg(feature = "log")]
-        log::debug!("command \"route {:?}\" error: {}", args, _err);
-    }
-
-    // remove the record file anyway
-    let _ = std::fs::remove_file(crate::get_state_file_path());
-
-    Ok(())
 }
 
 pub(crate) fn get_default_gateway() -> std::io::Result<(IpAddr, String)> {


### PR DESCRIPTION
Hi @ssrlive,

I have removed the explicit `tproxy_remove` function and replaced it with a `Drop` implementation, so that the removal also takes place in case there is an error (as suggested by @one-d-wide in https://github.com/blechschmidt/tun2proxy/pull/104).

This should also eliminate the need for the state file in most cases. I was hesitant to remove the code for the state file completely though, as it may still be needed in case tun2proxy is killed through external means, e.g. SIGKILL on Linux.

As of now, `tproxy_remove` never operated on the file anyway as it was always called on the `TProxyState`.

What do you think?